### PR TITLE
Add lightbulb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ cache:
   npm: true
 install:
 - travis_retry gem install s3_website -v 3.4.0
-- travis_retry pip install awscli --upgrade --user
 - travis_retry npm ci
+# the next command is to fix "SSLContext object is not available" error in awscli install
+- travis_retry pyenv global 3.6
+- travis_retry pip install awscli --upgrade --user
 script:
 - npm run build
 - npm run test:coverage -- --runInBand

--- a/src/lambdas/executeSingleDataflowProgram/dataflow-engine-runner.js
+++ b/src/lambdas/executeSingleDataflowProgram/dataflow-engine-runner.js
@@ -63,6 +63,7 @@ function getDataflowEngine() {
     new nodes.RelayReteNodeFactory(numSocket),
     new nodes.GeneratorReteNodeFactory(numSocket),
     new nodes.TimerReteNodeFactory(numSocket),
+    new nodes.LightBulbReteNodeFactory(numSocket),
     new nodes.DataStorageReteNodeFactory(numSocket)];
 
   components.forEach(c => engine.register(c));

--- a/src/lambdas/executeSingleDataflowProgram/nodes.js
+++ b/src/lambdas/executeSingleDataflowProgram/nodes.js
@@ -345,6 +345,30 @@ class TimerReteNodeFactory extends rete.Component {
   }
 }
 
+class LightBulbReteNodeFactory extends rete.Component {
+  constructor(numSocket) {
+    super("Light Bulb", numSocket);
+  }
+
+  builder(node) {
+    const inp1 = new Rete.Input("num1", "Number", this.numSocket);
+    return node
+      .addInput(inp1);
+  }
+
+  worker(node, inputs, outputs) {
+    const n1 = inputs.num1.length ? inputs.num1[0] : node.data.num1;
+    let result;
+    if (isNaN(n1)) {
+      result = NaN;
+    } else {
+      result = n1 !== 0 ? 1 : 0;
+    }
+
+    outputs.num = result;
+  }
+}
+
 class DataStorageReteNodeFactory extends rete.Component {
 
   constructor(numSocket) {
@@ -403,5 +427,6 @@ module.exports = {
   RelayReteNodeFactory,
   GeneratorReteNodeFactory,
   TimerReteNodeFactory,
+  LightBulbReteNodeFactory,
   DataStorageReteNodeFactory
 }

--- a/src/lambdas/executeSingleDataflowProgram/test/data/complex-with-data-storage-dataflow.js
+++ b/src/lambdas/executeSingleDataflowProgram/test/data/complex-with-data-storage-dataflow.js
@@ -247,6 +247,34 @@ module.exports = {
         270
       ],
       "name": "Transform"
-    }
+    },
+    "lightbulb-id":{
+      "id": "lightbulb-id",
+      "data":{
+         "num1": 0,
+         "nodeValue": 0
+      },
+      "inputs":{
+         "num1":{
+            "connections":[
+               {
+                  "node": "generator-id",
+                  "output": "num",
+                  "data": {
+
+                  }
+               }
+            ]
+         }
+      },
+      "outputs":{
+
+      },
+      "position": [
+        280,
+        280
+      ],
+      "name":"Light Bulb"
+   }
   }
 };

--- a/src/lambdas/executeSingleDataflowProgram/test/rete-test-with-dataflow-nodes.test.js
+++ b/src/lambdas/executeSingleDataflowProgram/test/rete-test-with-dataflow-nodes.test.js
@@ -28,6 +28,7 @@ describe('Engine', () => {
         new nodes.RelayReteNodeFactory(numSocket),
         new nodes.GeneratorReteNodeFactory(numSocket),
         new nodes.TimerReteNodeFactory(numSocket),
+        new nodes.LightBulbReteNodeFactory(numSocket),
         new nodes.DataStorageReteNodeFactory(numSocket)];
 
       components.map(c => {


### PR DESCRIPTION
This PR adds the ability for the `executeSingleDataflowProgram` to handle the new lightbulb blocks.

Note that the Travis build fails due to what appears to be test dependencies that aren't working.  Looking at previous commits, it appears that the Travis builds have been broken for a while.  It works locally, however, and since this build isn't being deployed anywhere, I'm not sure if it's worthwhile to try to fix this.  Failed build:
https://app.travis-ci.com/github/concord-consortium/dataflow-execution-framework/builds/233134095
Previous commits were failing too:
https://github.com/concord-consortium/dataflow-execution-framework/commits/lambdas

To really test this, we probably need to deploy this lambda and run a program that contains a lightbulb.  We probably want to merge this PR first:
https://github.com/concord-consortium/collaborative-learning/pull/987